### PR TITLE
CloudWatch Logs用のクラスに差し替える

### DIFF
--- a/ErrorNotificationLambda.Tests/ErrorNotificationLambda.Tests.csproj
+++ b/ErrorNotificationLambda.Tests/ErrorNotificationLambda.Tests.csproj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
 
+    <PackageReference Include="Amazon.Lambda.CloudWatchLogsEvents" Version="1.0.0" />
+
     <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.0.0" />
 

--- a/ErrorNotificationLambda.Tests/FunctionTest.cs
+++ b/ErrorNotificationLambda.Tests/FunctionTest.cs
@@ -6,26 +6,26 @@ namespace ErrorNotificationLambda.Tests
 {
     public class FunctionTest : IClassFixture<LaunchSettingsFixture>
     {
-	    LaunchSettingsFixture _fixture;
+        LaunchSettingsFixture _fixture;
 
         public FunctionTest(LaunchSettingsFixture fixture)
         {
             _fixture = fixture;
         }
 
-		[Fact]
+        [Fact]
         public async void TestErrorNotificationFunction()
         {
             var function = new Function();
             var context = new TestLambdaContext();
 
-	        var evnt = new CloudWatchLogsEvent()
-	        {
-		        Awslogs = new CloudWatchLogsEvent.Log
+            var evnt = new CloudWatchLogsEvent()
+            {
+                Awslogs = new CloudWatchLogsEvent.Log
                 {
                     EncodedData = "H4sIAAAAAAAAAHWPwQqCQBCGX0Xm7EFtK+smZBEUgXoLCdMhFtKV3akI8d0bLYmibvPPN3wz00CJxmQnTO41whwWQRIctmEcB6sQbFC3CjW3XW8kxpOpP+OC22d1Wml1qZkQGtoMsScxaczKN3plG8zlaHIta5KqWsozoTYw3/djzwhpLwivWFGHGpAFe7DL68JlBUk+l7KSN7tCOEJ4M3/qOI49vMHj+zCKdlFqLaU2ZHV2a4Ct/an0/ivdX8oYc1UVX860fQDQiMdxRQEAAA=="
                 }
-	        };
+            };
 
             var notification = await function.FunctionHandler(evnt, context);
 

--- a/ErrorNotificationLambda.Tests/FunctionTest.cs
+++ b/ErrorNotificationLambda.Tests/FunctionTest.cs
@@ -1,13 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Xunit;
-using Amazon.Lambda.Core;
+using Amazon.Lambda.CloudWatchLogsEvents;
 using Amazon.Lambda.TestUtilities;
-
-using ErrorNotificationLambda;
+using Xunit;
 
 namespace ErrorNotificationLambda.Tests
 {
@@ -15,26 +8,26 @@ namespace ErrorNotificationLambda.Tests
     {
 	    LaunchSettingsFixture _fixture;
 
-	    public FunctionTest(LaunchSettingsFixture fixture)
-	    {
-		    _fixture = fixture;
-	    }
+        public FunctionTest(LaunchSettingsFixture fixture)
+        {
+            _fixture = fixture;
+        }
 
 		[Fact]
         public async void TestErrorNotificationFunction()
         {
-			var function = new Function();
+            var function = new Function();
             var context = new TestLambdaContext();
 
-	        var evnt = new LogEvent
+	        var evnt = new CloudWatchLogsEvent()
 	        {
-		        Awslogs = new LogEvent.Log
-				{
-                    Data = "H4sIAAAAAAAAAHWPwQqCQBCGX0Xm7EFtK+smZBEUgXoLCdMhFtKV3akI8d0bLYmibvPPN3wz00CJxmQnTO41whwWQRIctmEcB6sQbFC3CjW3XW8kxpOpP+OC22d1Wml1qZkQGtoMsScxaczKN3plG8zlaHIta5KqWsozoTYw3/djzwhpLwivWFGHGpAFe7DL68JlBUk+l7KSN7tCOEJ4M3/qOI49vMHj+zCKdlFqLaU2ZHV2a4Ct/an0/ivdX8oYc1UVX860fQDQiMdxRQEAAA=="
-				}
+		        Awslogs = new CloudWatchLogsEvent.Log
+                {
+                    EncodedData = "H4sIAAAAAAAAAHWPwQqCQBCGX0Xm7EFtK+smZBEUgXoLCdMhFtKV3akI8d0bLYmibvPPN3wz00CJxmQnTO41whwWQRIctmEcB6sQbFC3CjW3XW8kxpOpP+OC22d1Wml1qZkQGtoMsScxaczKN3plG8zlaHIta5KqWsozoTYw3/djzwhpLwivWFGHGpAFe7DL68JlBUk+l7KSN7tCOEJ4M3/qOI49vMHj+zCKdlFqLaU2ZHV2a4Ct/an0/ivdX8oYc1UVX860fQDQiMdxRQEAAA=="
+                }
 	        };
 
-			var notification = await function.FunctionHandler(evnt, context);
+            var notification = await function.FunctionHandler(evnt, context);
 
             Assert.True(notification);
         }

--- a/ErrorNotificationLambda.Tests/LaunchSettingsFixture.cs
+++ b/ErrorNotificationLambda.Tests/LaunchSettingsFixture.cs
@@ -10,28 +10,28 @@ using Newtonsoft.Json.Linq;
 namespace ErrorNotificationLambda.Tests
 {
     public class LaunchSettingsFixture : IDisposable
-	{
+    {
         public LaunchSettingsFixture()
         {
             using (var file = File.OpenText("Properties" + Path.DirectorySeparatorChar + "launchSettings.json"))
             {
                 var reader = new JsonTextReader(file);
-	            var jObject = JObject.Load(reader);
+                var jObject = JObject.Load(reader);
 
-	            var variables = jObject
-    	            .GetValue("profiles")
-		            .SelectMany(profiles => profiles.Children())
-		            .SelectMany(profile => profile.Children<JProperty>())
-		            .Where(prop => prop.Name == "environmentVariables")
-		            .SelectMany(prop => prop.Value.Children<JProperty>())
-		            .ToList();
+                var variables = jObject
+                    .GetValue("profiles")
+                    .SelectMany(profiles => profiles.Children())
+                    .SelectMany(profile => profile.Children<JProperty>())
+                    .Where(prop => prop.Name == "environmentVariables")
+                    .SelectMany(prop => prop.Value.Children<JProperty>())
+                    .ToList();
 
-	            foreach (var variable in variables)
-	            {
-    	            Environment.SetEnvironmentVariable(variable.Name, variable.Value.ToString());
-	            }
-			}
-		}
+                foreach (var variable in variables)
+                {
+                    Environment.SetEnvironmentVariable(variable.Name, variable.Value.ToString());
+                }
+            }
+        }
 
         public void Dispose()
         {

--- a/ErrorNotificationLambda.Tests/LaunchSettingsFixture.cs
+++ b/ErrorNotificationLambda.Tests/LaunchSettingsFixture.cs
@@ -9,33 +9,33 @@ using Newtonsoft.Json.Linq;
 
 namespace ErrorNotificationLambda.Tests
 {
-	public class LaunchSettingsFixture : IDisposable
+    public class LaunchSettingsFixture : IDisposable
 	{
-		public LaunchSettingsFixture()
-		{
-			using (var file = File.OpenText("Properties" + Path.DirectorySeparatorChar + "launchSettings.json"))
-			{
-				var reader = new JsonTextReader(file);
-				var jObject = JObject.Load(reader);
+        public LaunchSettingsFixture()
+        {
+            using (var file = File.OpenText("Properties" + Path.DirectorySeparatorChar + "launchSettings.json"))
+            {
+                var reader = new JsonTextReader(file);
+	            var jObject = JObject.Load(reader);
 
-				var variables = jObject
-					.GetValue("profiles")
-					.SelectMany(profiles => profiles.Children())
-					.SelectMany(profile => profile.Children<JProperty>())
-					.Where(prop => prop.Name == "environmentVariables")
-					.SelectMany(prop => prop.Value.Children<JProperty>())
-					.ToList();
+	            var variables = jObject
+    	            .GetValue("profiles")
+		            .SelectMany(profiles => profiles.Children())
+		            .SelectMany(profile => profile.Children<JProperty>())
+		            .Where(prop => prop.Name == "environmentVariables")
+		            .SelectMany(prop => prop.Value.Children<JProperty>())
+		            .ToList();
 
-				foreach (var variable in variables)
-				{
-					Environment.SetEnvironmentVariable(variable.Name, variable.Value.ToString());
-				}
+	            foreach (var variable in variables)
+	            {
+    	            Environment.SetEnvironmentVariable(variable.Name, variable.Value.ToString());
+	            }
 			}
 		}
 
-		public void Dispose()
-		{
-			// ... clean up
-		}
-	}
+        public void Dispose()
+        {
+            // ... clean up
+        }
+    }
 }

--- a/ErrorNotificationLambda/ErrorNotificationLambda.csproj
+++ b/ErrorNotificationLambda/ErrorNotificationLambda.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.CloudWatchLogsEvents" Version="1.0.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
   </ItemGroup>

--- a/ErrorNotificationLambda/Function.cs
+++ b/ErrorNotificationLambda/Function.cs
@@ -70,7 +70,7 @@ namespace ErrorNotificationLambda
 		    {
 			    extractedMessage += item["message"].Value<string>() + Environment.NewLine;
 		    }
-			return extractedMessage;
+            return extractedMessage;
 	    }
 
     }

--- a/ErrorNotificationLambda/Function.cs
+++ b/ErrorNotificationLambda/Function.cs
@@ -1,16 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using System.Text;
-using System.IO;
-using System.IO.Compression;
-
+using Amazon.Lambda.CloudWatchLogsEvents;
+using Amazon.Lambda.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-using Amazon.Lambda.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
@@ -25,7 +24,7 @@ namespace ErrorNotificationLambda
 		/// <param name="logEvent"></param>
 		/// <param name="context"></param>
 		/// <returns></returns>
-		public async Task<bool> FunctionHandler(LogEvent logEvent, ILambdaContext context)
+		public async Task<bool> FunctionHandler(CloudWatchLogsEvent logEvent, ILambdaContext context)
 		{
 			var slackWebhookUrl = Environment.GetEnvironmentVariable("SLACK_WEBHOOK_URL");
 			var cloudWatchLogGroupUrl = Environment.GetEnvironmentVariable("CLOUDWATCH_LOG_GROUP_URL");
@@ -35,7 +34,7 @@ namespace ErrorNotificationLambda
 			{
 				channel = "dev",
 				username = "CloudWatch Notification",
-                text = $"{Decode(logEvent.Awslogs.Data)}"+ Environment.NewLine +
+                text = $"{GetMessage(logEvent.Awslogs.DecodeData())}"+ Environment.NewLine +
                        $"Logs: <{cloudWatchLogGroupUrl}|Click here>" + Environment.NewLine +
                        $"Metrics: <{cloudWatchMetricsUrl}|Click here>",
 			};
@@ -63,48 +62,16 @@ namespace ErrorNotificationLambda
 			return true;
 		}
 
-        private string Decode(string encodedString)
-        {
-            var decodedString = "";
-
-            byte[] data = Convert.FromBase64String(encodedString);
-
-            using (GZipStream stream = new GZipStream(new MemoryStream(data), CompressionMode.Decompress))
-            {
-                const int size = 4096;
-                byte[] buffer = new byte[size];
-                using (MemoryStream memory = new MemoryStream())
-                {
-                    int count = 0;
-                    do
-                    {
-                        count = stream.Read(buffer, 0, size);
-                        if (count > 0)
-                        {
-                            memory.Write(buffer, 0, count);
-                        }
-                    }
-                    while (count > 0);
-
-                    var messages = JObject.Parse(Encoding.UTF8.GetString(memory.ToArray())).GetValue("logEvents");
-                    foreach (var item in messages)
-                    {
-                        decodedString += item["message"].Value<string>() + Environment.NewLine;
-                    }
-                }
-            }
-
-            return decodedString;
-        }
+	    private static string GetMessage(string decodedData)
+	    {
+		    string extractedMessage = "";
+		    var messages = JObject.Parse(decodedData).GetValue("logEvents");
+		    foreach (var item in messages)
+		    {
+			    extractedMessage += item["message"].Value<string>() + Environment.NewLine;
+		    }
+			return extractedMessage;
+	    }
 
     }
-
-	public class LogEvent
-	{
-		public  Log Awslogs { get; set; }
-		public class Log
-		{
-			public  string Data { get; set; }
-		}
-	}
 }

--- a/ErrorNotificationLambda/Function.cs
+++ b/ErrorNotificationLambda/Function.cs
@@ -17,61 +17,59 @@ namespace ErrorNotificationLambda
 {
     public class Function
     {
-
-		/// <summary>
+        /// <summary>
         /// Notify contents waritten out on CloudWatch Logs
-		/// </summary>
-		/// <param name="logEvent"></param>
-		/// <param name="context"></param>
-		/// <returns></returns>
-		public async Task<bool> FunctionHandler(CloudWatchLogsEvent logEvent, ILambdaContext context)
-		{
-			var slackWebhookUrl = Environment.GetEnvironmentVariable("SLACK_WEBHOOK_URL");
-			var cloudWatchLogGroupUrl = Environment.GetEnvironmentVariable("CLOUDWATCH_LOG_GROUP_URL");
-			var cloudWatchMetricsUrl = Environment.GetEnvironmentVariable("CLOUDWATCH_METRICS_URL");
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public async Task<bool> FunctionHandler(CloudWatchLogsEvent logEvent, ILambdaContext context)
+        {
+            var slackWebhookUrl = Environment.GetEnvironmentVariable("SLACK_WEBHOOK_URL");
+            var cloudWatchLogGroupUrl = Environment.GetEnvironmentVariable("CLOUDWATCH_LOG_GROUP_URL");
+            var cloudWatchMetricsUrl = Environment.GetEnvironmentVariable("CLOUDWATCH_METRICS_URL");
 
-			var payload = new
-			{
-				channel = "dev",
-				username = "CloudWatch Notification",
-                text = $"{GetMessage(logEvent.Awslogs.DecodeData())}"+ Environment.NewLine +
+            var payload = new
+            {
+                channel = "dev",
+                username = "CloudWatch Notification",
+                text = $"{GetMessage(logEvent.Awslogs.DecodeData())}" + Environment.NewLine +
                        $"Logs: <{cloudWatchLogGroupUrl}|Click here>" + Environment.NewLine +
                        $"Metrics: <{cloudWatchMetricsUrl}|Click here>",
-			};
+            };
 
-			var jsonString = JsonConvert.SerializeObject(payload);
+            var jsonString = JsonConvert.SerializeObject(payload);
 
-			var content = new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				{ "payload", jsonString}
-			});
+            var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "payload", jsonString}
+            });
 
-			try
-			{
-				using (var client = new HttpClient())
-				{
-					await client.PostAsync(slackWebhookUrl, content);
-				}
-			}
-			catch (Exception e)
-			{
-				context.Logger.LogLine("error!!!!" + Environment.NewLine + $"{e.Message}" + Environment.NewLine + $"{e.StackTrace}");
-				throw;
-			}
-			
-			return true;
-		}
+            try
+            {
+                using (var client = new HttpClient())
+                {
+                    await client.PostAsync(slackWebhookUrl, content);
+                }
+            }
+            catch (Exception e)
+            {
+                context.Logger.LogLine("error!!!!" + Environment.NewLine + $"{e.Message}" + Environment.NewLine + $"{e.StackTrace}");
+                throw;
+            }
 
-	    private static string GetMessage(string decodedData)
-	    {
-		    string extractedMessage = "";
-		    var messages = JObject.Parse(decodedData).GetValue("logEvents");
-		    foreach (var item in messages)
-		    {
-			    extractedMessage += item["message"].Value<string>() + Environment.NewLine;
-		    }
+            return true;
+        }
+
+        private static string GetMessage(string decodedData)
+        {
+            string extractedMessage = "";
+            var messages = JObject.Parse(decodedData).GetValue("logEvents");
+            foreach (var item in messages)
+            {
+                extractedMessage += item["message"].Value<string>() + Environment.NewLine;
+            }
             return extractedMessage;
-	    }
-
+        }
     }
 }


### PR DESCRIPTION
# 概要
* CloudWatchLogsのイベントを自前のクラスにデシリアライズしていたが、`CloudWatchLogsEvent`が使えるようになったのでそちらに置き換える
* イベント内のデータのデコードまでサポートされるようになったので、デコードの自前実装部分は使わないようにする
* インデントおかしかったのでスペースに統一